### PR TITLE
write text chunks before IDAT

### DIFF
--- a/src/main/java/ar/com/hjg/pngj/chunks/PngChunkITXT.java
+++ b/src/main/java/ar/com/hjg/pngj/chunks/PngChunkITXT.java
@@ -21,6 +21,7 @@ public class PngChunkITXT extends PngChunkTextVar {
 	// http://www.w3.org/TR/PNG/#11iTXt
 	public PngChunkITXT(ImageInfo info) {
 		super(ID, info);
+		setPriority(true);
 	}
 
 	@Override

--- a/src/main/java/ar/com/hjg/pngj/chunks/PngChunkTEXT.java
+++ b/src/main/java/ar/com/hjg/pngj/chunks/PngChunkTEXT.java
@@ -13,10 +13,12 @@ public class PngChunkTEXT extends PngChunkTextVar {
 
 	public PngChunkTEXT(ImageInfo info) {
 		super(ID, info);
+		setPriority(true);
 	}
 
 	public PngChunkTEXT(ImageInfo info, String key, String val) {
 		super(ID, info);
+		setPriority(true);
 		setKeyVal(key, val);
 	}
 

--- a/src/main/java/ar/com/hjg/pngj/chunks/PngChunkZTXT.java
+++ b/src/main/java/ar/com/hjg/pngj/chunks/PngChunkZTXT.java
@@ -17,6 +17,7 @@ public class PngChunkZTXT extends PngChunkTextVar {
 	// http://www.w3.org/TR/PNG/#11zTXt
 	public PngChunkZTXT(ImageInfo info) {
 		super(ID, info);
+		setPriority(true);
 	}
 
 	@Override

--- a/src/test/java/ar/com/hjg/pngj/test/CustomChunkTest.java
+++ b/src/test/java/ar/com/hjg/pngj/test/CustomChunkTest.java
@@ -59,9 +59,9 @@ public class CustomChunkTest {
 		// TestCase.assertEquals("IHDR[13] prOp[256] pHYs[9] tEXt[59] IEND[0] ",
 		// chunks);
 		TestCase.assertEquals("Second chunk should be  prOp", "prOp",
-				pngr.getChunksList().getChunks().get(1).getRaw().id);
-		TestCase.assertEquals("Next chunk should be  pHYs", "pHYs",
 				pngr.getChunksList().getChunks().get(2).getRaw().id);
+		TestCase.assertEquals("Next chunk should be  pHYs", "pHYs",
+				pngr.getChunksList().getChunks().get(3).getRaw().id);
 		PngChunk chunk = pngr.getChunksList().getById1(PngChunkPROP.ID);
 		TestCase.assertTrue(chunk instanceof PngChunkUNKNOWN);
 	}
@@ -84,9 +84,9 @@ public class CustomChunkTest {
 		// TestCase.assertEquals("IHDR[13] prOp[256] pHYs[9] tEXt[59] IEND[0] ",
 		// chunks);
 		TestCase.assertEquals("Second chunk should be  prOp", "prOp",
-				pngr.getChunksList().getChunks().get(1).getRaw().id);
-		TestCase.assertEquals("Next chunk should be  pHYs", "pHYs",
 				pngr.getChunksList().getChunks().get(2).getRaw().id);
+		TestCase.assertEquals("Next chunk should be  pHYs", "pHYs",
+				pngr.getChunksList().getChunks().get(3).getRaw().id);
 		PngChunk chunk = pngr.getChunksList().getById1(PngChunkPROP.ID);
 		TestCase.assertTrue(chunk instanceof PngChunkPROP);
 		String val2 = ((PngChunkPROP) chunk).getProps().getProperty("mykey2");


### PR DESCRIPTION
Some readers expect the text chunks to be written before the IDAT chunk.
This also allows to parse them without the need to skip to the end of the file.
Apache commons imaging also writes them before IDAT.

So this PR adapts this behavior.
The custom chunk test needed to be adapted since the chunk order changed.